### PR TITLE
Handle hyphen and spaces before marker and parameterize the marker-syntax mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,32 @@
 # vim-sh-heredoc-highlighting
-This vim plugin enables syntax highlighting for code snippets in shell (sh, bash, ksh, etc.) here-docs.
+This vim plugin enables syntax highlighting for code snippets in shell (sh,
+bash, ksh, etc.) here-docs.
 
-It will highlight shell, perl and python snippets when it sees heredocs
-delimited by the markers SHELL, PERL or PYTHON respectively. You should be able
-to extend this to whatever you want very easily by modifying
-[`heredoc-sh.vim`](after/syntax/sh/heredoc-sh.vim) following the pattern that's apparent. I'd make it
-configurable, but vimscript continues to elude me.
+It will highlight code snippets when it sees heredocs delimited by markers
+named after the corresponding language, e.g.:
 
-## Override / Extends the heredoc highlighting
+```sh
+python <<PYTHON
+import sys
+print(sys.path)
+PYTHON
+```
+
+The languages enabled by default are:
+
+- GNUPLOT
+- JSON
+- LUA
+- PERL
+- PYTHON
+- SHELL
+
+To configure additional languages, put a dictionary mapping markers to syntax
+names in the variable `g:heredocs`: e.g.
 
 ```vim
-" basically a dictionary with shape {[MARKER]: syntax} that merges with or overrides the existing g:heredocs_default
-let g:heredocs = {"GRAPHQL": "graphql"}
+" in your vimrc
+let g:heredocs = {"SQL": "sql"}
 ```
+
+would highlight heredocs delimited by `SQL` using `syntax/sql.vim`.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ delimited by the markers SHELL, PERL or PYTHON respectively. You should be able
 to extend this to whatever you want very easily by modifying
 [`heredoc-sh.vim`](after/syntax/sh/heredoc-sh.vim) following the pattern that's apparent. I'd make it
 configurable, but vimscript continues to elude me.
+
+## Override / Extends the heredoc highlighting
+
+```vim
+" basically a dictionary with shape {[MARKER]: syntax} that merges with or overrides the existing g:heredocs_default
+let g:heredocs = {"GRAPHQL": "graphql"}
+```

--- a/after/syntax/sh/heredoc-sh.vim
+++ b/after/syntax/sh/heredoc-sh.vim
@@ -1,41 +1,19 @@
-let s:bcs = b:current_syntax
-unlet b:current_syntax
-syntax include @sh syntax/sh.vim
-unlet b:current_syntax
-syntax include @json syntax/json.vim
-unlet b:current_syntax
-syntax include @python syntax/python.vim
-unlet b:current_syntax
-syntax include @gnuplot syntax/gnuplot.vim
-unlet b:current_syntax
-execute "syntax include @perl syntax/perl.vim"
-unlet b:current_syntax
-syntax include @lua syntax/lua.vim
-let b:current_syntax = s:bcs
-
 syntax cluster shHeredocHL contains=@sh
 
 function! Def_heredoc(marker, contains)
-    "let s:bcs = b:current_syntax
-    "unlet b:current_syntax
-    "execute "syntax include @" . a:contains . " syntax/" . a:contains . ".vim"
-    "let b:current_syntax = s:bcs
+    let s:bcs = b:current_syntax
+    unlet b:current_syntax
+    " Load the relavant syntax file
+    execute "syntax include @" . a:contains . " syntax/" . a:contains . ".vim"
+    let b:current_syntax = s:bcs
 
-    execute "syntax region heredoc" . a:marker . " matchgroup=Snip "
-        \ "start=+<<\s*'". a:marker . "'.*$+ end=+^" . a:marker . "\s*$+ containedin=@sh,@shHereDocHL contains=@" . a:contains
-    execute "syntax region heredoc" . a:marker . "2 matchgroup=Snip "
-        \ "start=+<<\s*\"". a:marker . "\".*$+ end=+^" . a:marker . "\s*$+ containedin=@sh,@shHereDocHL contains=@" . a:contains
-    execute "syntax region heredoc" . a:marker . "3 matchgroup=Snip "
-        \ "start=+<<\s*". a:marker . ".*$+ end=+^" . a:marker . "\s*$+ containedin=@sh,@shHereDocHL contains=@" . a:contains
-
-    execute "syntax cluster shHeredocHL add=heredoc" . a:marker
-    execute "syntax cluster shHeredocHL add=heredoc" . a:marker . "2"
-    execute "syntax cluster shHeredocHL add=heredoc" . a:marker . "3"
+    for [region, quotation] in items({"heredoc" . a:marker . "Plain": "", "heredoc" . a:marker . "SingleQuote": "'", "heredoc" . a:marker . "DoubleQuote": "\""})
+        execute "syntax region " . region . " matchgroup=Snip start=+<<[-]\\?\\s*" . quotation . a:marker . quotation . ".*$+ end=+\\s*" . a:marker . "\\s*$+ containedin=@sh,@shHereDocHL contains=@" . a:contains
+        execute "syntax cluster shHeredocHL add=" . region
+    endfor
 endfunction
 
-call Def_heredoc("PYTHON", "python")
-call Def_heredoc("LUA", "lua")
-call Def_heredoc("PERL", "perl")
-call Def_heredoc("SHELL", "sh")
-call Def_heredoc("GNUPLOT", "gnuplot")
-call Def_heredoc("JSON", "json")
+let g:heredocs_default = #{PYTHON: "python", LUA: "lua", PERL: "perl", SHELL: "sh", GNUPLOT: "gnuplot", JSON: "json"}
+for [marker, contains] in items(extend(g:heredocs_default, get(g:, 'heredocs', {})))
+    call Def_heredoc(marker, contains)
+endfor


### PR DESCRIPTION
Hi @acarapetis,

# Disclaimer
Please do correct me if I wrote something wrong or unidiomatic since I rarely write in Vimscript.

# Description
I came across looking for a heredoc syntax highlighting plugin and found this works great.  Just that the syntax highlight stops when there is a hyphen and/or some whitespaces after `<<`.

I have also parameterized the declaration of the marker-syntax mapping such that it could be extended/overridden in `.vimrc` without having to fork the repo.

# Type of change

- [x] Bugfix (handle `<<-` and escape the escape sequence inside double-quotes (`\s` -> `\\s`)
- [x] New Feature (takes `g:heredocs` as an override of the `g:heredocs_default` in the after syntax script)

# Notes
I think for completeness the highlights within the heredoc should also ignore shell substitution if the start marker is surrounded by single-quote, which is not implemented in this PR.

Thanks!

Best Regards,
Leo

Reference: https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/V3_chap02.html#tag_18_07_04